### PR TITLE
Image Per Class Limit

### DIFF
--- a/css/tool-styles/containers.css
+++ b/css/tool-styles/containers.css
@@ -20,3 +20,7 @@
     height: 75px;
     scrollbar-width: none;
 }
+
+#maxed-class{
+    background-color: rgb(0, 97, 37) !important;
+}


### PR DESCRIPTION
Method:
If class total from the global label count is equal to the limit per class, any following occurrences of the label/class in any annotation/prediction will be filtered out. Leaving only the limit of the images containing the label to balance the image count balance.